### PR TITLE
Revert "Update frontmatter requirements in hsp-001.md"

### DIFF
--- a/HSPs/hsp-001.md
+++ b/HSPs/hsp-001.md
@@ -81,6 +81,7 @@ All HSPs must use the standard template with the following structure:
 ### Required Frontmatter
 ```yaml
 ---
+hsp: <number>
 title: <max 44 characters>
 description: <max 140 characters>
 author: <name(s) and contact info>


### PR DESCRIPTION
This reverts commit df6b6eb004a74b99a8acd1b978b0d0449f5aa78e.

This commit was made directly to `main` erroneously, without a pull request. I'll lock the `main` branch now so this doesn't happen again.